### PR TITLE
Whitespace fix in MixedContentNormalizer

### DIFF
--- a/src/org/daisy/pipeline/core/transformer/Transformer.java
+++ b/src/org/daisy/pipeline/core/transformer/Transformer.java
@@ -155,8 +155,7 @@ public abstract class Transformer implements BusListener {
 	private String getName() {
 		return this.getTransformerInfo().getNiceName();
 	}
-	
-		
+
 	/**
 	 * Executes the Transformer with the specified parameters.
 	 * @param parameters a collection of parameters
@@ -189,7 +188,7 @@ public abstract class Transformer implements BusListener {
 	
 
 	final protected UserReplyEvent getUserInput(String message, String defaultValue) {
-		if (!mIsInteractive) {
+		if (!mIsInteractive||mInputListener==null) { // JH 151126: Added null pointer check to allow unit testing of transformers
 			return new UserReplyEvent(this,defaultValue);			
 		}		
 		return mInputListener.getUserReply(new RequestEvent(this,message));		
@@ -288,7 +287,9 @@ public abstract class Transformer implements BusListener {
 	 * Convenience method to emit a message.
 	 */
 	public void sendMessage(String message, MessageEvent.Type type, MessageEvent.Cause cause, Location location) {
-		mEventBus.publish(new TaskMessageEvent(this.mTask,message,type,cause,location));
+		if (mTask!=null) { // JH 151126: Added null pointer check to allow unit testing of transformers
+			mEventBus.publish(new TaskMessageEvent(this.mTask,message,type,cause,location));
+		}
 	}
 	
 	/**
@@ -296,7 +297,9 @@ public abstract class Transformer implements BusListener {
 	 * @param progress A double between 0.0 and 1.0 inclusive
 	 */
 	protected void sendMessage(double progress) {
-		mEventBus.publish(new TaskProgressChangeEvent(this.mTask,progress));   
+		if (mTask!=null) { // JH 151126: Added null pointer check to allow unit testing of transformers
+			mEventBus.publish(new TaskProgressChangeEvent(this.mTask,progress));
+		}
 	}
 	
 	/**

--- a/test/int_daisy_mixedContentNormalizer/MixedContentNormalizerTest.java
+++ b/test/int_daisy_mixedContentNormalizer/MixedContentNormalizerTest.java
@@ -1,0 +1,43 @@
+package int_daisy_mixedContentNormalizer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.daisy.pipeline.exception.TransformerDisabledException;
+import org.daisy.pipeline.exception.TransformerRunException;
+import org.junit.Test;
+import org.hamcrest.Matcher.*;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class MixedContentNormalizerTest {
+
+	@Test
+	public void testNormalizer_01() throws TransformerRunException, TransformerDisabledException, IOException {
+		
+		// Use same line endings for all os environments, golden master created using *nix-style line endings
+		System.setProperty("line.separator", "\n");
+
+		Map<String,String> parameters = new HashMap<String, String>();
+		 
+		String testNormalizeOutputName = "test/int_daisy_mixedContentNormalizer/test_normalize_output.xml";
+		String testNormalizeInputName = "test/int_daisy_mixedContentNormalizer/test_normalize_input.xml";
+        String testGoldenMasterName = "test/int_daisy_mixedContentNormalizer/golden_master_test_normalize.xml";
+		parameters.put("input", testNormalizeInputName);
+		parameters.put("output", testNormalizeOutputName);
+		parameters.put("addSyncPoints", "true");
+		parameters.put("implementation", "dom");
+		
+		MixedContentNormalizer n = new MixedContentNormalizer(null, false);
+		n.execute(parameters);
+		
+		File goldenMaster = new File(testGoldenMasterName);
+		File testOutput = new File(testNormalizeOutputName);
+		assertThat(FileUtils.contentEquals(goldenMaster, testOutput), is(Boolean.TRUE));
+	}
+}

--- a/test/int_daisy_mixedContentNormalizer/golden_master_test_normalize.xml
+++ b/test/int_daisy_mixedContentNormalizer/golden_master_test_normalize.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?><dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" version="2005-3" xml:lang="sv" xmlns:annon="http://www.daisy.org/ns/pipeline/annon" xmlns:smil="http://www.w3.org/2001/SMIL20/" xmlns:vnml="http://www.tpb.se/vnml">
+               http://www.daisy.org/z3986/2005/dtbook/"        xmlns:dtbook="http://www.daisy.org/z3986/2005/dtbook/
+	<head>
+		<meta content="C00000" name="dtb:uid"/>
+		<meta content="Himmelska kroppar, inkarnation, blick, kroppslighet" name="dc:Title"/>
+		<meta content="Sigurdson, Ola" name="dc:Creator"/>
+		<meta content="2013-11-20" name="dc:Date"/>
+		<meta content="MTM" name="dc:Publisher"/>
+		<meta content="sv" name="dc:Language"/>
+		<meta content="AEL Data" name="track:Supplier"/>
+		<meta content="2013-12-10" name="track:SuppliedDate"/>
+		<meta content="" name="track:Signum"/>
+		<meta content="2011-2" name="track:Guidelines"/>
+	</head>
+	<book>
+		<frontmatter>
+			<doctitle smil:sync="true">Himmelska kroppar</doctitle>
+			<docauthor annon:before="Av" smil:sync="true">Ola Sigurdson</docauthor>
+		</frontmatter>
+		<bodymatter>
+			<level1>
+				<pagenum id="page-288" page="normal" smil:sync="true">288</pagenum>
+				<h1>
+					<sent smil:sync="true">KROPPSLIGHET</sent>
+				</h1>
+					<p>
+						<sent><span class="normalized" smil:sync="true">Så föreställde sig till exempel <em>Platon</em> i dialogen <em>Timaios</em> inte bara den <em>mänskliga</em> kroppen som ett kosmos, utan också kosmos som en kropp, och här var han enig med stora delar av sin samtid.</span> <noteref idref="#c09036" smil:sync="true">36</noteref> <span class="normalized" smil:sync="true">Därmed skulle varje skarp <em>distinktion</em> mellan en figurativ och en faktisk kropp men även mellan en social och en individuell kropp försvinna.</span></sent>
+						<sent><span class="normalized" smil:sync="true"><em>Så</em> föreställde sig till <em>exempel</em> Platon i dialogen <em>Timaios</em> inte <em>bara</em> den mänskliga kroppen som ett kosmos, utan också kosmos som en kropp, och här var han enig med stora delar av sin samtid.</span><noteref idref="#c09036" smil:sync="true">36</noteref> <span class="normalized" smil:sync="true">Därmed skulle varje skarp distinktion mellan en figurativ och en faktisk kropp men även mellan en social och en individuell kropp försvinna.</span></sent>
+						<sent><span class="normalized" smil:sync="true">test<em> av0</em> något <em> av1</em> <em> av2</em> <em> av3</em></span><noteref idref="#c09036" smil:sync="true">36</noteref><span class="normalized" smil:sync="true">Textextra</span></sent>
+					</p>
+			</level1>
+		</bodymatter>
+	</book>
+</dtbook>

--- a/test/int_daisy_mixedContentNormalizer/test_normalize_input.xml
+++ b/test/int_daisy_mixedContentNormalizer/test_normalize_input.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" xmlns:vnml="http://www.tpb.se/vnml" xmlns:annon="http://www.daisy.org/ns/pipeline/annon" xml:lang="sv" version="2005-3">
+               http://www.daisy.org/z3986/2005/dtbook/"        xmlns:dtbook="http://www.daisy.org/z3986/2005/dtbook/
+	<head>
+		<meta name="dtb:uid" content="C00000"/>
+		<meta name="dc:Title" content="Himmelska kroppar, inkarnation, blick, kroppslighet"/>
+		<meta name="dc:Creator" content="Sigurdson, Ola"/>
+		<meta name="dc:Date" content="2013-11-20"/>
+		<meta name="dc:Publisher" content="MTM"/>
+		<meta name="dc:Language" content="sv"/>
+		<meta name="track:Supplier" content="AEL Data"/>
+		<meta name="track:SuppliedDate" content="2013-12-10"/>
+		<meta name="track:Signum" content=""/>
+		<meta name="track:Guidelines" content="2011-2"/>
+	</head>
+	<book>
+		<frontmatter>
+			<doctitle>Himmelska kroppar</doctitle>
+			<docauthor annon:before="Av">Ola Sigurdson</docauthor>
+		</frontmatter>
+		<bodymatter>
+			<level1>
+				<pagenum page="normal" id="page-288">288</pagenum>
+				<h1>
+					<sent>KROPPSLIGHET</sent>
+				</h1>
+					<p>
+						<sent>Så föreställde sig till exempel <em>Platon</em> i dialogen <em>Timaios</em> inte bara den <em>mänskliga</em> kroppen som ett kosmos, utan också kosmos som en kropp, och här var han enig med stora delar av sin samtid. <noteref idref="#c09036">36</noteref> Därmed skulle varje skarp <em>distinktion</em> mellan en figurativ och en faktisk kropp men även mellan en social och en individuell kropp försvinna.</sent>
+						<sent><em>Så</em> föreställde sig till <em>exempel</em> Platon i dialogen <em>Timaios</em> inte <em>bara</em> den mänskliga kroppen som ett kosmos, utan också kosmos som en kropp, och här var han enig med stora delar av sin samtid.<noteref idref="#c09036">36</noteref> Därmed skulle varje skarp distinktion mellan en figurativ och en faktisk kropp men även mellan en social och en individuell kropp försvinna.</sent>
+						<sent>test<em> av0</em> något <em> av1</em> <em> av2</em> <em> av3</em><noteref idref="#c09036">36</noteref>Textextra</sent>
+					</p>
+			</level1>
+		</bodymatter>
+	</book>
+</dtbook>

--- a/transformers/int_daisy_mixedContentNormalizer/config.xml
+++ b/transformers/int_daisy_mixedContentNormalizer/config.xml
@@ -38,7 +38,7 @@ Defines a one per document element scope outside of which the sync point locator
 -->
 
 	<namespace uri="http://www.daisy.org/z3986/2005/dtbook/" xmlns:dtbook="http://www.daisy.org/z3986/2005/dtbook/">
-		<ignore asWhitespace=".">
+		<ignore>
 			<dtbook:abbr />
 			<dtbook:acronym />
 			<dtbook:em />
@@ -69,7 +69,7 @@ Defines a one per document element scope outside of which the sync point locator
 	</namespace>
 
 	<namespace uri="http://www.w3.org/1999/xhtml" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-		<ignore asWhitespace="."> 
+		<ignore> 
 			<xhtml:em />
 			<xhtml:strong />
 			<xhtml:b />


### PR DESCRIPTION
Handling of inline elements had a side effect. Whitespace after the last inline element got moved into the begeinning of the next higher level xml-element.