### PR TITLE
Improve the Unix launcher script to handle Java versions > 1.8

### DIFF
--- a/launchers/pipeline.sh
+++ b/launchers/pipeline.sh
@@ -1,29 +1,37 @@
 #!/bin/bash
 ############################################
 # Simple launch script for the command line
-# version of the Daisy Pipeline   
+# version of the Daisy Pipeline
 ############################################
 
 # This is the path to Java. Edit this variable to suite your needs.
 JAVA=`which java 2> /dev/null`
 #JAVA=/opt/jre1.5.0_04/bin/java
 
-
-
-
 # Test java version
 if [ -n "$JAVA" ]
 then
-  JAVAVERSION=`$JAVA -version 2>&1 | grep version | cut -d '"' -f 2 | cut -d '.' -f 1-2`
-  JAVAMAJOR=`echo $JAVAVERSION | cut -d '.' -f 1`
-  JAVAMINOR=`echo $JAVAVERSION | cut -d '.' -f 2`
-  if [ $JAVAMAJOR -lt 1 -o $JAVAMINOR -lt 5 ]
-  then    
+  # Get the full version string and extract major version
+  JAVA_VERSION_OUTPUT=`$JAVA -version 2>&1 | head -1`
+
+  # Handle both old format (1.x.y) and new format (x.y.z)
+  if echo "$JAVA_VERSION_OUTPUT" | grep -q '"1\.'
+  then
+    # Old format: "1.8.0_xxx" -> extract second number
+    JAVA_MAJOR_VERSION=`echo "$JAVA_VERSION_OUTPUT" | cut -d'"' -f2 | cut -d'.' -f2`
+  else
+    # New format: "11.0.x" or "17.0.x" -> extract first number
+    JAVA_MAJOR_VERSION=`echo "$JAVA_VERSION_OUTPUT" | cut -d'"' -f2 | cut -d'.' -f1`
+  fi
+
+  echo "$JAVA_MAJOR_VERSION"
+  if [ "$JAVA_MAJOR_VERSION" -lt 8 ]
+  then
     echo
-    echo "Error: This application requires Java 5 (or later) to run. Only" 
-    echo "       version $JAVAVERSION was found on your system path. Make sure" 
-    echo "       Java 5 (or later) is installed on the system and edit this"
-    echo "       pipeline.sh script to insert the path to the 'java' command."  
+    echo "Error: This application requires Java 8 (or later) to run. Only"
+    echo "       version $JAVA_MAJOR_VERSION was found on your system path. Make sure"
+    echo "       Java 8 (or later) is installed on the system and edit this"
+    echo "       pipeline.sh script to insert the path to the 'java' command."
     echo
     echo "       Current (incorrect) java path: $JAVA"
     echo
@@ -31,14 +39,12 @@ then
   fi
 else
   echo
-  echo "Error: Java 5 was not found on your system path. Make sure Java 5"
+  echo "Error: Java 8 was not found on your system path. Make sure Java 8"
   echo "       (or later) is installed on the system and edit this"
-  echo "       pipelins.sh script to insert the path to the 'java' command."  
+  echo "       pipeline.sh script to insert the path to the 'java' command."
   echo
   exit 1
 fi
-
-
 
 # Set classpath
 if [[ "$(uname)" == 'Linux' ]]; then

--- a/launchers/pipeline.sh
+++ b/launchers/pipeline.sh
@@ -20,8 +20,8 @@ then
     # Old format: "1.8.0_xxx" -> extract second number
     JAVA_MAJOR_VERSION=`echo "$JAVA_VERSION_OUTPUT" | cut -d'"' -f2 | cut -d'.' -f2`
   else
-    # New format: "11.0.x" or "17.0.x" -> extract first number
-    JAVA_MAJOR_VERSION=`echo "$JAVA_VERSION_OUTPUT" | cut -d'"' -f2 | cut -d'.' -f1`
+    # New format: "11.0.x" or "17.0.x" or "25-ea" -> extract first number
+    JAVA_MAJOR_VERSION=`echo "$JAVA_VERSION_OUTPUT" | cut -d'"' -f2 | cut -d'.' -f1 | cut -d'-' -f1`
   fi
 
   echo "$JAVA_MAJOR_VERSION"


### PR DESCRIPTION
Improve the launcher script so that it can handle java verion strings of the form "1.8.0_xxx" as well as "11.0.x"