### PR TITLE
Normalize LaTeX headlines

### DIFF
--- a/transformers/se_tpb_dtbook2latex/dtbook2latex_common.xsl
+++ b/transformers/se_tpb_dtbook2latex/dtbook2latex_common.xsl
@@ -889,7 +889,10 @@
        </xsl:otherwise>
      </xsl:choose>
      <xsl:text>{</xsl:text>
-     <xsl:apply-templates/>
+     <xsl:variable name="headline-content">
+       <xsl:apply-templates/>
+     </xsl:variable>
+     <xsl:value-of select="normalize-space($headline-content)"/>
      <xsl:text>}&#10;</xsl:text>
      <xsl:apply-templates select="my:first-pagenum-anchor-before-headline(.)" mode="inside-headline"/>
    </xsl:template>


### PR DESCRIPTION
so that whitespace before and after is trimmed